### PR TITLE
Support for django 1.9 under Python 3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.3.0 (unreleased)
+-------------------------
+* Added support for Django on Python 3.
+
 0.2.1 (2014-10-12)
 ==================
 

--- a/django_markdown2/templatetags/md2.py
+++ b/django_markdown2/templatetags/md2.py
@@ -7,7 +7,14 @@ This code is based on django's markup contrib.
 
 from django import template
 from django.conf import settings
-from django.utils.encoding import force_unicode
+import sys
+
+if sys.version_info.major == 2:
+    from django.utils.encoding import force_unicode
+else:
+    force_unicode = lambda text: text
+
+
 from django.utils.safestring import mark_safe
 
 register = template.Library()
@@ -33,7 +40,7 @@ def markdown(value, arg=''):
         import markdown2
     except ImportError:
         if settings.DEBUG:
-            raise template.TemplateSyntaxError, "Error in {% markdown %} filter: The python-markdown2 library isn't installed."
+            raise template.TemplateSyntaxError("Error in {% markdown %} filter: The python-markdown2 library isn't installed.")
         return force_unicode(value)
     else:
         def parse_extra(extra):


### PR DESCRIPTION
These changes make it possible to use the module with Django using Python3, without breaking it under Python2.
